### PR TITLE
Fix incorrect fullpem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-06-11
+
+### Added
+ - Print a short summary including paths after writing files to disk
+
+### Changes
+ - PEM output option now follows [rfc4346](https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2) certificate lists order
+ - Challenge verification may take longer now, user is informed in if it takes long.
+
+### Fixes
+ - Full paths to output files are no longer miss their parent directory if it contained a dot
+
 ## [0.2.6] - 2023-06-03
 
 ### Added
@@ -14,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.5] - 2023-06-02
 
 ### Fixes
- - Continue y/n no longer continues when chosing n
+ - Continue y/n no longer continues when choosing n
 
 ## [0.2.4] - 2023-06-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,8 @@ dependencies = [
 [[package]]
 name = "instant-acme"
 version = "0.3.2"
-source = "git+https://github.com/instant-labs/instant-acme?branch=http-client-bounds#591b99ada2814ff0970702218c68b0c9be938ef9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b94f62e8dd2b561e7646bd0cc92e4c9d940859fc1c146ad8ab6e5d3e6f7c03"
 dependencies = [
  "base64 0.21.2",
  "hyper",
@@ -1438,7 +1439,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "renewc"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "renewc"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,6 @@ dependencies = [
  "haproxy-config",
  "hyper",
  "instant-acme",
- "is-terminal",
  "itertools",
  "libc",
  "libproc",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renewc"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["David Kleingeld <opensource@davidsk.dev>"]
 edition = "2021"
 rust-version = "1.70"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -3,6 +3,7 @@ name = "renewc"
 version = "0.2.6"
 authors = ["David Kleingeld <opensource@davidsk.dev>"]
 edition = "2021"
+rust-version = "1.70"
 description = "Certificate renewal, with advanced diagnostics without installing anything"
 license = "GNUv3"
 readme = "README.md"
@@ -32,7 +33,6 @@ hyper = { version = "0.14", features = ["client"] }
 itertools = "0.10"
 
 haproxy-config = "0.4"
-is-terminal = "0.4"
 rand = "0.8"
 # supports-color feature ends up enabling atty which has a RUSTSEC 
 # advisory against it. For now colors will ben enabled always.

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -42,7 +42,7 @@ yasna = "0.5"
 async-trait = "0.1"
 data-encoding = "2.4"
 pem = "2"
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.24", features = ["derive"] }
 
 [dev-dependencies]
 libc = "0.2"

--- a/main/src/advise.rs
+++ b/main/src/advise.rs
@@ -116,8 +116,7 @@ pub fn given_existing(config: &Config, cert: &Option<Info>, stdout: &mut impl Wr
 
 #[must_use]
 fn exit_requested(w: &mut impl Write, config: &Config, question: &str) -> bool {
-    use is_terminal::IsTerminal;
-
+    use std::io::IsTerminal;
     info!(w, "{}", question);
 
     if config.non_interactive || !std::io::stdin().is_terminal() {

--- a/main/src/cert.rs
+++ b/main/src/cert.rs
@@ -19,17 +19,18 @@ pub struct MaybeSigned<P: PemItem> {
 impl<P: PemItem> std::fmt::Debug for MaybeSigned<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MaybeSigned")
-            .field("certificate", &"censored for security")
+            .field("certificate", &"hidden to prevent security leaks")
             .field(
                 "private_key",
-                &self.private_key.as_ref().map(|_| "censored for security"),
+                &self.private_key.as_ref().map(|_| "hidden to prevent security leaks"),
             )
             .field(
                 "chain",
                 &self
                     .chain
                     .iter()
-                    .map(|_| "censored for security")
+                    .map(|p| p.as_bytes())
+                    .map(String::from_utf8)
                     .collect::<Vec<_>>(),
             )
             .finish()
@@ -49,14 +50,15 @@ pub struct Signed<P: PemItem> {
 impl<P: PemItem> std::fmt::Debug for Signed<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Signed")
-            .field("certificate", &"censored for security")
-            .field("private_key", &"censored for security")
+            .field("certificate", &"hidden to prevent security leaks")
+            .field("private_key", &"hidden to prevent security leaks")
             .field(
                 "chain",
                 &self
                     .chain
                     .iter()
-                    .map(|_| "censored for security")
+                    .map(|p| p.as_bytes())
+                    .map(String::from_utf8)
                     .collect::<Vec<_>>(),
             )
             .finish()
@@ -123,7 +125,8 @@ where
     P: PemItem,
 {
     /// expects the signed certificate to be the first certificate
-    /// item
+    /// item (see certificate list in
+    /// [rfc4346 section 7.4.2](https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2)
     pub(super) fn from_pem(bytes: Vec<u8>) -> eyre::Result<Self> {
         let mut pem = String::from_utf8(bytes)?;
         let start_key = pem.rfind("-----BEGIN PRIVATE KEY-----");
@@ -133,15 +136,18 @@ where
             .transpose()
             .wrap_err("failed to extract private key")?;
 
-        const DELIMITER: &'static str = "-----BEGIN CERTIFICATE-----";
-        let start_cert = pem.find(DELIMITER).map(|i| i + DELIMITER.len());
-        let certificate = start_cert.map(|i| pem.split_off(i)).ok_or(eyre::eyre!(
-            "Can not find a certificate label in the pem content"
-        ))?;
-        let certificate = PemItem::from_pem(certificate, Label::Certificate)
-            .wrap_err("failed to extract signed certificate")?;
+        const DELIMITER: &'static str = "-----END CERTIFICATE-----";
+        let post_signed_cert = pem.find(DELIMITER).map(|i| i + DELIMITER.len());
+        let chain = post_signed_cert
+            .map(|i| pem.split_off(i))
+            .ok_or(eyre::eyre!(
+                "Can not find a certificate label in the pem content"
+            ))?;
+        let chain = P::chain_from_pem(chain.into_bytes()).wrap_err("failed to extract chain")?;
 
-        let chain = P::chain_from_pem(pem.into_bytes()).wrap_err("failed to extract chain")?;
+        // only signed cert left in pem after we split off key and chain
+        let certificate = PemItem::from_pem(pem, Label::Certificate)
+            .wrap_err("failed to extract signed certificate")?;
 
         Ok(MaybeSigned {
             certificate,
@@ -157,21 +163,22 @@ mod tests {
 
     #[test]
     fn acme_output_to_signed() {
-        let full_chain = "
------BEGIN CERTIFICATE-----
-BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B81
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B81
------END CERTIFICATE-----
------BEGIN CERTIFICATE----- 
-BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B81
------END CERTIFICATE-----
------BEGIN CERTIFICATE----- 
-BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B81
------END CERTIFICATE-----
-            "
-        .to_string();
+        let signed_cert = "-----BEGIN CERTIFICATE-----\r
+BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B81\r
+-----END CERTIFICATE-----\r\n";
+        let chain0 = "-----BEGIN CERTIFICATE-----\r
+BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B82\r
+-----END CERTIFICATE-----\r\n";
+        let chain1 = "-----BEGIN CERTIFICATE-----\r
+BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B83\r
+-----END CERTIFICATE-----\r\n";
+        let chain2 = "-----BEGIN CERTIFICATE-----\r
+BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B84\r
+-----END CERTIFICATE-----\r\n";
+
+        // in a single file the certificate is always before the
+        // full chain
+        let certs = format!("{signed_cert}\r\n{chain0}\r\n{chain1}\r\n{chain2}");
 
         let key = "
 -----BEGIN PRIVATE KEY----- 
@@ -180,7 +187,12 @@ BQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRfouS0E6yLB+fT3eNI3x8V9B81
             "
         .to_string();
 
-        Signed::<pem::Pem>::from_key_and_fullchain(key, full_chain.clone()).unwrap();
-        MaybeSigned::<pem::Pem>::from_pem(full_chain.into_bytes()).unwrap();
+        Signed::<pem::Pem>::from_key_and_fullchain(key, certs.clone()).unwrap();
+        let res = MaybeSigned::<pem::Pem>::from_pem(certs.into_bytes()).unwrap();
+        assert_eq!(res.certificate.to_string(), signed_cert);
+        let mut chain = res.chain.into_iter().map(|p| p.to_string());
+        assert_eq!(chain.next().unwrap(), chain0);
+        assert_eq!(chain.next().unwrap(), chain1);
+        assert_eq!(chain.next().unwrap(), chain2);
     }
 }

--- a/main/src/cert/format.rs
+++ b/main/src/cert/format.rs
@@ -3,8 +3,8 @@ use color_eyre::eyre::{self, bail, Context};
 use pem::Pem;
 
 impl PemItem for Pem {
-    fn into_bytes(self) -> Vec<u8> {
-        pem::encode(&self).into_bytes()
+    fn as_bytes(&self) -> Vec<u8> {
+        pem::encode(self).into_bytes()
     }
 
     fn from_pem(pem_encoded: impl AsRef<[u8]>, label: Label) -> eyre::Result<Self> {
@@ -36,7 +36,7 @@ impl PemItem for Pem {
 
 pub trait PemItem: Sized {
     #[must_use]
-    fn into_bytes(self) -> Vec<u8>;
+    fn as_bytes(&self) -> Vec<u8>;
 
     fn from_pem(encoded: impl AsRef<[u8]>, label: Label) -> eyre::Result<Self>
     where
@@ -118,6 +118,6 @@ mod tests {
         let der = Pem::from_pem(ROOT_CA, Label::Certificate).unwrap().der();
         assert_ne!(der.clone().into_bytes(), ROOT_CA);
         let pem: Pem = der.to_pem(Label::Certificate);
-        assert_eq!(pem.into_bytes(), ROOT_CA);
+        assert_eq!(pem.as_bytes(), ROOT_CA);
     }
 }

--- a/main/src/cert/info.rs
+++ b/main/src/cert/info.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use super::format::PemItem;
 use super::{load, Signed};
 use crate::config;
@@ -19,8 +21,11 @@ pub struct Info {
 }
 
 impl Info {
-    pub fn from_disk(config: &config::Config) -> eyre::Result<Option<Self>> {
-        let Some(signed) = load::from_disk::<pem::Pem>(config)? else {
+    pub fn from_disk(
+        config: &config::Config,
+        stdout: &mut impl Write,
+    ) -> eyre::Result<Option<Self>> {
+        let Some(signed) = load::from_disk::<pem::Pem>(config, stdout)? else {
             return Ok(None);
         };
         let info = analyze(signed)?;

--- a/main/src/config.rs
+++ b/main/src/config.rs
@@ -21,8 +21,8 @@ use paths::{CertPath, name};
 /// a client needs to check if our signed certificate is authentic. Our
 /// certificates private key.
 pub enum Output {
-    /// Use PEM encoding. Store the chain, the signed certificate and the private
-    /// key in the same file. File extension will be 'pem'.
+    /// Use PEM encoding. Store the signed certificate, the chain and the private
+    /// key in the same file in that order. File extension will be 'pem'.
     ///
     /// Amongst others needed by: Haproxy
     Pem,

--- a/main/src/config.rs
+++ b/main/src/config.rs
@@ -13,28 +13,31 @@ mod paths;
 pub use args::{Commands, InstallArgs, OutputArgs};
 use paths::{CertPath, name};
 
-#[derive(clap::ValueEnum, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
 /// How to store the output.
 ///
-/// After a certificate has been issued we have three outputs. Our signed
-/// certificate. A certificate chain, it contains all the certificates
-/// a client needs to check if our signed certificate is authentic. Our
-/// certificates private key.
+/// After a certificate has been issued we have three outputs. 
+///  - The signed certificate for our domain(s). 
+///  - A certificate chain, it contains all the certificates
+///    a client needs to check if our signed certificate is authentic. 
+///  - Our certificates private key.
 pub enum Output {
     /// Use PEM encoding. Store the signed certificate, the chain and the private
-    /// key in the same file in that order. File extension will be 'pem'.
+    /// key in the same file in that order. File extension will be 'pem'. 
     ///
     /// Amongst others needed by: Haproxy
     Pem,
 
-    /// Use PEM encoding. Store the certificate chain and signed certificate in the
-    /// same file. Keep the private key in another. File extensions will be 'pem'.
+    /// Use PEM encoding. Store the signed certificate and certificate chain in the
+    /// same file in that order. Keep the private key in another. 
+    /// File extensions will be 'pem'.
     ///
     /// Amongst others needed by: Nginx and Apache
     #[default]
     PemSeperateKey,
     /// Use PEM encoding. Store the signed certificate and private key in the
-    /// same file and the chain in another. File extensions will be 'pem'.
+    /// same file in that order. The chain is stored in another file. 
+    /// File extensions will be 'pem'.
     PemSeperateChain,
     /// Use PEM encoding. Store the signed certificate, private key and chain
     /// all in their own file. File extensions will be 'pem'.

--- a/main/src/config/paths.rs
+++ b/main/src/config/paths.rs
@@ -1,7 +1,7 @@
 use color_eyre::{eyre, Help};
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use tracing::warn;
-
 
 use super::{Encoding, Output};
 
@@ -61,9 +61,6 @@ pub(super) fn fix_extension(encoding: Encoding, path: &Path) -> eyre::Result<Pat
 pub struct CertPath(PathBuf);
 
 impl CertPath {
-    pub fn as_path(&self) -> &Path {
-        &self.0
-    }
     pub fn new(output: &Output, cert_path: &Path, name: &str) -> eyre::Result<Self> {
         let encoding = Encoding::from(output);
 
@@ -79,9 +76,6 @@ impl CertPath {
 pub struct KeyPath(PathBuf);
 
 impl KeyPath {
-    pub fn as_path(&self) -> &Path {
-        &self.0
-    }
     pub fn new(
         output: &Output,
         cert_path: &Path,
@@ -100,10 +94,6 @@ impl KeyPath {
 pub struct ChainPath(PathBuf);
 
 impl ChainPath {
-    pub fn as_path(&self) -> &Path {
-        &self.0
-    }
-
     pub fn new(
         output: &Output,
         cert_path: &Path,
@@ -118,6 +108,25 @@ impl ChainPath {
     }
 }
 
+macro_rules! impl_path_struct {
+    ($struct:ident) => {
+        impl Display for $struct {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_fmt(format_args!("{}", self.0.display()))
+            }
+        }
+
+        impl $struct {
+            pub fn as_path(&self) -> &Path {
+                &self.0
+            }
+        }
+    };
+}
+
+impl_path_struct!(ChainPath);
+impl_path_struct!(CertPath);
+impl_path_struct!(KeyPath);
 
 #[cfg(test)]
 mod tests {

--- a/main/src/config/paths/derive.rs
+++ b/main/src/config/paths/derive.rs
@@ -4,10 +4,7 @@ use tracing::instrument;
 
 #[instrument(level = "debug", ret)]
 pub(crate) fn derive_path(cert_path: &Path, name: &str, ty: &str, extension: &str) -> PathBuf {
-    let mut path = dir(cert_path);
-    path.set_file_name(format!("{name}_{ty}"));
-    path.set_extension(extension);
-    path
+    dir(cert_path).join(&format!("{name}_{ty}")).with_extension(extension)
 }
 
 pub fn name(domains: &[impl AsRef<str>]) -> eyre::Result<String> {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -41,7 +41,8 @@ async fn main() -> eyre::Result<()> {
             let Some(certs): Option<Signed<pem::Pem>> = run(&mut InstantAcme {}, &mut stdout, &config, debug).await? else {
                 return Ok(());
             };
-            cert::store::on_disk(&config, certs).wrap_err("Could not write out certificates")?;
+            cert::store::on_disk(&config, certs, &mut stdout)
+                .wrap_err("Could not write out certificates")?;
             if let Some(service) = &config.reload {
                 install::reload(service)?;
             }

--- a/main/src/renew.rs
+++ b/main/src/renew.rs
@@ -1,12 +1,12 @@
-use std::io::Read;
+use std::io::{Read, Write};
 use std::string::String;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use color_eyre::eyre::{self, Context};
 use color_eyre::Help;
 use rcgen::{Certificate, CertificateParams, DistinguishedName};
-use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tokio::time::{sleep, sleep_until, Instant};
+use tracing::{debug, error};
 
 use crate::cert::format::PemItem;
 use crate::cert::Signed;
@@ -100,11 +100,22 @@ async fn prepare_challenge(order: &mut Order) -> eyre::Result<Vec<Http01Challeng
     Ok(challenges)
 }
 
+trait TimeLeft {
+    fn duration_until(&self) -> Duration;
+}
+
+impl TimeLeft for Instant {
+    fn duration_until(&self) -> Duration {
+        Instant::now().saturating_duration_since(*self)
+    }
+}
+
 // Exponentially back off until the order becomes ready or invalid.
 #[tracing::instrument(skip_all)]
 async fn wait_for_order_rdy<'a>(
     order: &'a mut Order,
     challenges: &[Http01Challenge],
+    stdout: &mut impl Write,
     debug: bool,
 ) -> eyre::Result<&'a OrderState> {
     // Let the server know we're ready to accept the challenges.
@@ -112,11 +123,12 @@ async fn wait_for_order_rdy<'a>(
         order.set_challenge_ready(url).await.unwrap();
     }
 
-    let first_attempt = Instant::now();
+    const MAX_DURATION: Duration = Duration::from_secs(10);
+    let mut next_attempt = Instant::now();
+    let deadline = Instant::now() + MAX_DURATION;
+    let mut print_info = Some(Instant::now() + Duration::from_secs(2));
     let mut delay = Duration::from_millis(250);
-    const MAX_DELAY: Duration = Duration::from_secs(10);
     let mut attempt = 0;
-    info!("waiting for certificate authority to verify our challange");
     let state = loop {
         order
             .refresh()
@@ -130,25 +142,30 @@ async fn wait_for_order_rdy<'a>(
             other => other,
         };
 
+        if Instant::now() > deadline {
+            break Err(eyre::eyre!("order is not ready in time"))
+                .with_note(|| format!("last order status: {status:?}"));
+        }
         delay *= 2;
         attempt += 1;
+        next_attempt = deadline.min(next_attempt + delay);
+
         debug!(
             attempt,
             "order is not ready (status: {status:?}), waiting {delay:?} before retrying"
         );
 
-        const INFO_DELAY: Duration = Duration::from_secs(2);
-        if first_attempt.elapsed() >= INFO_DELAY {
-            info!(
+        // None is smaller then all Some
+        if print_info.is_some_and(|p| next_attempt > p) {
+            print_info = None; // only print info once
+            writeln!(
+                stdout,
                 "certificate authority is taking longer then expected, waiting {} more seconds",
-                (MAX_DELAY - INFO_DELAY).as_secs()
+                deadline.duration_until().as_secs()
             )
+            .unwrap();
         }
-        if first_attempt.elapsed() >= MAX_DELAY {
-            break Err(eyre::eyre!("order is not ready in time"))
-                .with_note(|| format!("last order status: {status:?}"));
-        }
-        sleep(delay).await;
+        sleep_until(next_attempt).await;
     };
 
     if debug && state.is_err() {
@@ -180,7 +197,11 @@ fn prepare_sign_request(names: &[String]) -> Result<(Certificate, Vec<u8>), rcge
 }
 
 #[tracing::instrument(skip_all)]
-pub async fn renew<P: PemItem>(config: &Config, debug: bool) -> eyre::Result<Signed<P>> {
+pub async fn renew<P: PemItem>(
+    config: &Config,
+    stdout: &mut impl Write,
+    debug: bool,
+) -> eyre::Result<Signed<P>> {
     let account = account(config).await?;
     let mut order = order(&account, &config.domains)
         .await
@@ -193,7 +214,14 @@ pub async fn renew<P: PemItem>(config: &Config, debug: bool) -> eyre::Result<Sig
     diagnostics::reachable::server(config, &challenges)
         .await
         .wrap_err("Domain does not route to this application")?;
-    let ready = wait_for_order_rdy(&mut order, &challenges, debug);
+    write!(
+        stdout,
+        "waiting: certificate authority is verifing we own the domain"
+    )
+    .unwrap();
+    stdout.flush().unwrap();
+
+    let ready = wait_for_order_rdy(&mut order, &challenges, stdout, debug);
     let state = tokio::select!(
         res = ready => res?,
         e = server => {
@@ -206,6 +234,13 @@ pub async fn renew<P: PemItem>(config: &Config, debug: bool) -> eyre::Result<Sig
         return Err(eyre::eyre!("order is invalid"))
             .suggestion("is the challenge server reachable?");
     }
+    writeln!(stdout, ", done").unwrap();
+    write!(
+        stdout,
+        "waiting: certificate authority is signing our certificate"
+    )
+    .unwrap();
+    stdout.flush().unwrap();
 
     let names: Vec<String> = challenges.into_iter().map(|ch| ch.id).collect();
     let (cert, csr) = prepare_sign_request(&names)?;
@@ -218,6 +253,7 @@ pub async fn renew<P: PemItem>(config: &Config, debug: bool) -> eyre::Result<Sig
         }
     };
 
+    writeln!(stdout, ", done").unwrap();
     Signed::from_key_and_fullchain(cert.serialize_private_key_pem(), full_chain_pem)
 }
 
@@ -225,7 +261,12 @@ pub struct InstantAcme;
 
 #[async_trait::async_trait]
 impl super::ACME for InstantAcme {
-    async fn renew<P: PemItem>(&self, config: &Config, debug: bool) -> eyre::Result<Signed<P>> {
-        renew(config, debug).await
+    async fn renew<P: PemItem, W: Write + Send>(
+        &self,
+        config: &Config,
+        stdout: &mut W,
+        debug: bool,
+    ) -> eyre::Result<Signed<P>> {
+        renew(config, stdout, debug).await
     }
 }

--- a/main/tests/diagnostics.rs
+++ b/main/tests/diagnostics.rs
@@ -4,6 +4,7 @@ use pem::Pem;
 use tempfile::tempdir;
 
 mod shared;
+use shared::TestPrinter;
 
 #[cfg(target_os = "linux")]
 #[tokio::test]
@@ -24,7 +25,7 @@ async fn haproxy_binds_port() {
     let mut config = Config::test(bound_port, &dir.path().join("test_cert"));
     config.diagnostics.haproxy.path = path;
 
-    let err = run::<Pem>(&mut InstantAcme {}, &mut std::io::stdout(), &config, true)
+    let err = run::<Pem>(&mut InstantAcme {}, &mut TestPrinter, &config, true)
         .await
         .unwrap_err();
     let test = format!("{err:?}");
@@ -45,7 +46,7 @@ async fn insufficent_permissions() {
     let dir = tempdir().unwrap();
     let config = Config::test(42, &dir.path().join("test_cert"));
 
-    let err = run::<Pem>(&mut InstantAcme {}, &mut std::io::stdout(), &config, true)
+    let err = run::<Pem>(&mut InstantAcme {}, &mut TestPrinter, &config, true)
         .await
         .unwrap_err();
     let test = format!("{err:?}");

--- a/main/tests/format.rs
+++ b/main/tests/format.rs
@@ -5,6 +5,7 @@ use renewc::Config;
 mod shared;
 use renewc::config::Output;
 use shared::gen_cert;
+use shared::TestPrinter;
 use time::OffsetDateTime;
 
 #[tokio::test]
@@ -17,7 +18,7 @@ async fn der_and_pem_equal() {
     let valid_till = OffsetDateTime::now_utc();
     let original: Signed<Pem> = gen_cert::generate_cert_with_chain(valid_till, false);
 
-    let mut config = Config::test(42, &dir.path().join("test_cert"));
+    let mut config = Config::test(42, &dir.path());
     config.production = false;
 
     for format in [
@@ -28,8 +29,8 @@ async fn der_and_pem_equal() {
         Output::Der,
     ]
     {
-        config.output_config.output = dbg!(&format).clone();
-        store::on_disk(&config, original.clone()).unwrap();
+        config.output_config.output = dbg!(format);
+        store::on_disk(&config, original.clone(), &mut TestPrinter).unwrap();
         let loaded = load::from_disk(&config).unwrap().unwrap();
 
         assert_eq!(

--- a/main/tests/format.rs
+++ b/main/tests/format.rs
@@ -31,7 +31,7 @@ async fn der_and_pem_equal() {
     {
         config.output_config.output = dbg!(format);
         store::on_disk(&config, original.clone(), &mut TestPrinter).unwrap();
-        let loaded = load::from_disk(&config).unwrap().unwrap();
+        let loaded = load::from_disk(&config, &mut TestPrinter).unwrap().unwrap();
 
         assert_eq!(
             loaded, original,

--- a/main/tests/shared/gen_cert.rs
+++ b/main/tests/shared/gen_cert.rs
@@ -23,7 +23,7 @@ fn ca_cert(is_staging: bool) -> Certificate {
 pub fn client_cert(valid_till: OffsetDateTime) -> Certificate {
     let subject_alt_names = vec!["example.org".to_string()];
     let mut params = CertificateParams::new(subject_alt_names);
-    params.not_after = valid_till;
+    params.not_after = dbg!(valid_till);
     Certificate::from_params(params).unwrap()
 }
 
@@ -65,7 +65,7 @@ pub fn generate_cert_with_chain<P: PemItem>(
 pub fn write_single_chain<P: PemItem>(dir: &TempDir, signed: Signed<P>) -> PathBuf {
     let path = dir.path().join("cert.pem");
     let bytes: Vec<u8> = Itertools::intersperse(
-        signed.chain.into_iter().map(P::into_bytes),
+        signed.chain.iter().map(P::as_bytes),
         "\r\n".as_bytes().to_vec(),
     )
     .flatten()
@@ -78,7 +78,9 @@ pub fn valid() -> OffsetDateTime {
     OffsetDateTime::from_unix_timestamp(16_734_790_789).unwrap()
 }
 
-#[allow(dead_code)]
+// not actually dead, modules in integration tests 
+// give compile warnings if code is not used in each integration test file
+#[allow(dead_code)] 
 pub fn expired() -> OffsetDateTime {
     OffsetDateTime::from_unix_timestamp(1_683_145_489).unwrap()
 }

--- a/main/tests/shared/mod.rs
+++ b/main/tests/shared/mod.rs
@@ -72,7 +72,6 @@ mod tests {
         let acme = TestAcme::new(valid());
         let cert: Signed<Pem> = acme.renew(&Config::test(42, &dir.path().join("test_cert")), true).await.unwrap();
 
-        dbg!(&cert.private_key);
         let private_key = String::from_utf8(cert.private_key.into_bytes()).unwrap();
         assert!(!private_key.is_empty());
         assert!(private_key.contains("END PRIVATE KEY"));


### PR DESCRIPTION
### Added
 - Print a short summary including paths after writing files to disk

### Changes
 - PEM output option now follows [rfc4346](https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2) certificate lists order
 - Challenge verification may take longer now, user is informed in if it takes long.

### Fixes
 - Full paths to output files are no longer miss their parent directory if it contained a dot
